### PR TITLE
Odometry test

### DIFF
--- a/src/main/deploy/swerve/modules/backleft.json
+++ b/src/main/deploy/swerve/modules/backleft.json
@@ -3,7 +3,7 @@
       "front": -10.25,
       "left": 10.25
     },
-    "absoluteEncoderOffset": 237.56832,
+    "absoluteEncoderOffset": 57.56832,
     "drive": {
       "type": "sparkmax",
       "id": 5,
@@ -20,7 +20,7 @@
       "canbus": "rio"
     },
     "inverted": {
-      "drive": false,
+      "drive": true,
       "angle": true
     },
     "absoluteEncoderInverted": false

--- a/src/main/deploy/swerve/modules/backleft.json
+++ b/src/main/deploy/swerve/modules/backleft.json
@@ -3,7 +3,7 @@
       "front": -10.25,
       "left": 10.25
     },
-    "absoluteEncoderOffset": 57.56832,
+    "absoluteEncoderOffset": 237.56832,
     "drive": {
       "type": "sparkmax",
       "id": 5,

--- a/src/main/deploy/swerve/modules/backright.json
+++ b/src/main/deploy/swerve/modules/backright.json
@@ -3,7 +3,7 @@
       "front": -10.25,
       "left": -10.25
     },
-    "absoluteEncoderOffset": 210.76164,
+    "absoluteEncoderOffset": 30.76164,
     "drive": {
       "type": "sparkmax",
       "id": 7,

--- a/src/main/deploy/swerve/modules/backright.json
+++ b/src/main/deploy/swerve/modules/backright.json
@@ -3,7 +3,7 @@
       "front": -10.25,
       "left": -10.25
     },
-    "absoluteEncoderOffset": 30.76164,
+    "absoluteEncoderOffset": 210.76164,
     "drive": {
       "type": "sparkmax",
       "id": 7,
@@ -20,7 +20,7 @@
       "canbus": "rio"
     },
     "inverted": {
-      "drive": false,
+      "drive": true,
       "angle": true
     },
     "absoluteEncoderInverted": false

--- a/src/main/deploy/swerve/modules/frontleft.json
+++ b/src/main/deploy/swerve/modules/frontleft.json
@@ -3,7 +3,7 @@
       "front": 10.25,
       "left": 10.25
     },
-    "absoluteEncoderOffset": 268.9452,
+    "absoluteEncoderOffset": 88.9452,
     "drive": {
       "type": "sparkmax",
       "id": 3,
@@ -20,7 +20,7 @@
       "canbus": "rio"
     },
     "inverted": {
-      "drive": false,
+      "drive": true,
       "angle": true
     },
     "absoluteEncoderInverted": false

--- a/src/main/deploy/swerve/modules/frontleft.json
+++ b/src/main/deploy/swerve/modules/frontleft.json
@@ -3,7 +3,7 @@
       "front": 10.25,
       "left": 10.25
     },
-    "absoluteEncoderOffset": 88.9452,
+    "absoluteEncoderOffset": 268.9452,
     "drive": {
       "type": "sparkmax",
       "id": 3,

--- a/src/main/deploy/swerve/modules/frontright.json
+++ b/src/main/deploy/swerve/modules/frontright.json
@@ -3,7 +3,7 @@
       "front": 10.25,
       "left": -10.25
     },
-    "absoluteEncoderOffset": 229.92192,
+    "absoluteEncoderOffset": 49.92192,
     "drive": {
       "type": "sparkmax",
       "id": 1,

--- a/src/main/deploy/swerve/modules/frontright.json
+++ b/src/main/deploy/swerve/modules/frontright.json
@@ -3,7 +3,7 @@
       "front": 10.25,
       "left": -10.25
     },
-    "absoluteEncoderOffset": 49.92192,
+    "absoluteEncoderOffset": 229.92192,
     "drive": {
       "type": "sparkmax",
       "id": 1,
@@ -20,7 +20,7 @@
       "canbus": "rio"
     },
     "inverted": {
-      "drive": false,
+      "drive": true,
       "angle": true
     },
     "absoluteEncoderInverted": false

--- a/src/main/deploy/swerve/swervedrive.json
+++ b/src/main/deploy/swerve/swervedrive.json
@@ -4,7 +4,7 @@
       "id": 0,
       "canbus": null
     },
-    "invertedIMU": true,
+    "invertedIMU": false,
     "modules": [
       "frontleft.json",
       "frontright.json",

--- a/src/main/deploy/swerve/swervedrive.json
+++ b/src/main/deploy/swerve/swervedrive.json
@@ -4,7 +4,7 @@
       "id": 0,
       "canbus": null
     },
-    "invertedIMU": false,
+    "invertedIMU": true,
     "modules": [
       "frontleft.json",
       "frontright.json",

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -73,13 +73,13 @@ public class RobotContainer
     // left stick controls translation
     // right stick controls the angular velocity of the robot
     Command driveFieldOrientedAnglularVelocity = drivebase.driveCommand(
-        () -> MathUtil.applyDeadband(driverXbox.getLeftY() * 0.75, OperatorConstants.LEFT_Y_DEADBAND),
-        () -> MathUtil.applyDeadband(driverXbox.getLeftX() * 0.75, OperatorConstants.LEFT_X_DEADBAND),
+        () -> MathUtil.applyDeadband(-driverXbox.getLeftY() * 0.75, OperatorConstants.LEFT_Y_DEADBAND),
+        () -> MathUtil.applyDeadband(-driverXbox.getLeftX() * 0.75, OperatorConstants.LEFT_X_DEADBAND),
         () -> driverXbox.getRightX() * 0.75);
 
     Command driveFieldOrientedDirectAngleSim = drivebase.simDriveCommand(
-        () -> MathUtil.applyDeadband(driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
-        () -> MathUtil.applyDeadband(driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
+        () -> MathUtil.applyDeadband(-driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
+        () -> MathUtil.applyDeadband(-driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
         () -> driverXbox.getRawAxis(2));
 
     drivebase.setDefaultCommand(

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -75,12 +75,12 @@ public class RobotContainer
     Command driveFieldOrientedAnglularVelocity = drivebase.driveCommand(
         () -> MathUtil.applyDeadband(-driverXbox.getLeftY() * 0.75, OperatorConstants.LEFT_Y_DEADBAND),
         () -> MathUtil.applyDeadband(-driverXbox.getLeftX() * 0.75, OperatorConstants.LEFT_X_DEADBAND),
-        () -> driverXbox.getRightX() * 0.75);
+        () -> -driverXbox.getRightX() * 0.75);
 
     Command driveFieldOrientedDirectAngleSim = drivebase.simDriveCommand(
         () -> MathUtil.applyDeadband(-driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
         () -> MathUtil.applyDeadband(-driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
-        () -> driverXbox.getRawAxis(2));
+        () -> -driverXbox.getRawAxis(2));
 
     drivebase.setDefaultCommand(
         !RobotBase.isSimulation() ? driveFieldOrientedAnglularVelocity : driveFieldOrientedDirectAngleSim);

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -45,11 +45,11 @@ public class RobotContainer
     configureBindings();
 
     AbsoluteDriveAdv closedAbsoluteDriveAdv = new AbsoluteDriveAdv(drivebase,
-                                                                   () -> -MathUtil.applyDeadband(driverXbox.getLeftY(),
+                                                                   () -> -MathUtil.applyDeadband(-driverXbox.getLeftY(),
                                                                                                 OperatorConstants.LEFT_Y_DEADBAND),
-                                                                   () -> -MathUtil.applyDeadband(driverXbox.getLeftX(),
+                                                                   () -> -MathUtil.applyDeadband(-driverXbox.getLeftX(),
                                                                                                 OperatorConstants.LEFT_X_DEADBAND),
-                                                                   () -> -MathUtil.applyDeadband(driverXbox.getRightX(),
+                                                                   () -> -MathUtil.applyDeadband(-driverXbox.getRightX(),
                                                                                                 OperatorConstants.RIGHT_X_DEADBAND),
                                                                    driverXbox.getHID()::getYButtonPressed,
                                                                    driverXbox.getHID()::getAButtonPressed,
@@ -62,10 +62,10 @@ public class RobotContainer
     // left stick controls translation
     // right stick controls the desired angle NOT angular rotation
     Command driveFieldOrientedDirectAngle = drivebase.driveCommand(
-        () -> MathUtil.applyDeadband(driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
-        () -> MathUtil.applyDeadband(driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
-        () -> driverXbox.getRightX(),
-        () -> driverXbox.getRightY());
+        () -> MathUtil.applyDeadband(-driverXbox.getLeftY(), OperatorConstants.LEFT_Y_DEADBAND),
+        () -> MathUtil.applyDeadband(-driverXbox.getLeftX(), OperatorConstants.LEFT_X_DEADBAND),
+        () -> -driverXbox.getRightX(),
+        () -> -driverXbox.getRightY());
 
     // Applies deadbands and inverts controls because joysticks
     // are back-right positive while robot


### PR DESCRIPTION
Inverted XBOX controls to align with North-West convention.  Inverted drive motors on all swerve modules.  Returned CANCoder offsets to value that Falxon X provides (removed 180 degree offset).  Odometry now aligns with physical robot movement.